### PR TITLE
fix $language smarty global variable name override

### DIFF
--- a/clerk.php
+++ b/clerk.php
@@ -2519,7 +2519,7 @@ CLERKJS;
         $this->context->smarty->assign(array(
             'clerk_public_key' => Configuration::get('CLERK_PUBLIC_KEY', $this->context->language->id, null, $this->context->shop->id),
             'clerk_datasync_collect_emails' => Configuration::get('CLERK_DATASYNC_COLLECT_EMAILS', $this->context->language->id, null, $this->context->shop->id),
-            'language' => $this->language
+            'clerk_language_name' => $this->language
         ));
         $View =  $this->display(__FILE__, 'clerk_js.tpl');
 

--- a/views/templates/hook/clerk_js.tpl
+++ b/views/templates/hook/clerk_js.tpl
@@ -41,8 +41,8 @@
         {if isset($clerk_datasync_collect_emails)}
         collect_email: {$clerk_datasync_collect_emails},
         {/if}
-        {if isset($language)}
-        language: '{$language}'
+        {if isset($clerk_language_name)}
+        language: '{$clerk_language_name}'
         {/if}
     });
    


### PR DESCRIPTION
as shown here, https://devdocs.prestashop.com/1.7/modules/creation/displaying-content-in-front-office/\#embedding-a-template-in-the-theme
smarty variables are global, and prestashop defines a $language object that is used in various places in the template
so we must rename $language variable used in views/templates/hook/clerk_js.tpl to something unique

fixes https://github.com/clerkio/clerk-prestashop/issues/11