### PR TITLE
fix config key length and add migration to keep existing one

### DIFF
--- a/clerk.php
+++ b/clerk.php
@@ -114,9 +114,10 @@ class Clerk extends Module
             Shop::setContext(Shop::CONTEXT_ALL);
         }
 
-        //Install tab
-
-        $tabId = (int) Tab::getIdFromClassName('AdminClerkDashboard');
+        //Install tab — query DB directly to avoid stale class_index.php cache
+        $tabId = (int) Db::getInstance()->getValue(
+            "SELECT `id_tab` FROM `" . _DB_PREFIX_ . "tab` WHERE `class_name` = 'AdminClerkDashboard'"
+        );
         if (!$tabId) {
             $tabId = null;
         }

--- a/clerk.php
+++ b/clerk.php
@@ -78,7 +78,7 @@ class Clerk extends Module
         $this->api = new Clerk_Api();
         $this->name = 'clerk';
         $this->tab = 'advertising_marketing';
-        $this->version = '6.9.2';
+        $this->version = '6.9.3';
         $this->author = 'Clerk';
         $this->need_instance = 0;
         $this->ps_versions_compliancy = array('min' => '1.5', 'max' => _PS_VERSION_);
@@ -230,21 +230,21 @@ class Clerk extends Module
             Configuration::updateValue('CLERK_LIVESEARCH_TEMPLATE', $liveSearchTemplateValues, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_LIVESEARCH_SELECTOR', $liveSearchSelector, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_LIVESEARCH_FORM_SELECTOR', $liveSearchFormSelector, false, null, $shop['id_shop']);
-            Configuration::updateValue('CLERK_LIVESEARCH_NUMBER_SUGGESTIONS', $dropdownNumberValues, false, null, $shop['id_shop']);
-            Configuration::updateValue('CLERK_LIVESEARCH_NUMBER_CATEGORIES', $dropdownNumberValues, false, null, $shop['id_shop']);
+            Configuration::updateValue('CLERK_LS_NUM_SUGGESTIONS', $dropdownNumberValues, false, null, $shop['id_shop']);
+            Configuration::updateValue('CLERK_LS_NUM_CATEGORIES', $dropdownNumberValues, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_LIVESEARCH_NUMBER_PAGES', $dropdownNumberValues, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_LIVESEARCH_PAGES_TYPE', $pagesTypeValues, false, null, $shop['id_shop']);
-            Configuration::updateValue('CLERK_LIVESEARCH_DROPDOWN_POSITION', $dropdownPositioningValues, false, null, $shop['id_shop']);
+            Configuration::updateValue('CLERK_LS_DROPDOWN_POSITION', $dropdownPositioningValues, false, null, $shop['id_shop']);
 
             Configuration::updateValue('CLERK_POWERSTEP_ENABLED', $falseValues, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_POWERSTEP_TYPE', $powerstepTypeValues, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_POWERSTEP_TEMPLATES', $powerstepTemplateValues, false, null, $shop['id_shop']);
 
-            Configuration::updateValue('CLERK_DATASYNC_USE_REAL_TIME_UPDATES', $falseValues, false, null, $shop['id_shop']);
+            Configuration::updateValue('CLERK_DSYNC_REALTIME_UPDATES', $falseValues, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_DATASYNC_INCLUDE_PAGES', $falseValues, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_DATASYNC_PAGE_FIELDS', $emptyValues, false, null, $shop['id_shop']);
-            Configuration::updateValue('CLERK_DATASYNC_INCLUDE_OUT_OF_STOCK_PRODUCTS', $falseValues, false, null, $shop['id_shop']);
-            Configuration::updateValue('CLERK_DATASYNC_INCLUDE_ONLY_LOCAL_STOCK', $falseValues, false, null, $shop['id_shop']);
+            Configuration::updateValue('CLERK_DSYNC_INCL_OOS_PRODUCTS', $falseValues, false, null, $shop['id_shop']);
+            Configuration::updateValue('CLERK_DSYNC_ONLY_LOCAL_STOCK', $falseValues, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_DATASYNC_STATUS_SCOPE_SHOP', $falseValues, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_DATASYNC_CONTEXTUAL_VAT', $falseValues, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_DATASYNC_QUERY_BY_STOCK', $falseValues, false, null, $shop['id_shop']);
@@ -257,7 +257,7 @@ class Clerk extends Module
             Configuration::updateValue('CLERK_DATASYNC_PRODUCT_FEATURES', $falseValues, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_DATASYNC_PRODUCT_TAGS', $falseValues, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_IMAGE_SIZE', $imageValue, false, null, $shop['id_shop']);
-            Configuration::updateValue('CLERK_DATASYNC_DISABLE_CUSTOMER_SYNC', $falseValues, false, null, $shop['id_shop']);
+            Configuration::updateValue('CLERK_DSYNC_DISABLE_CUST_SYNC', $falseValues, false, null, $shop['id_shop']);
 
             Configuration::updateValue('CLERK_EXIT_INTENT_ENABLED', $falseValues, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_EXIT_INTENT_TEMPLATE', $exitIntentTemplateValues, false, null, $shop['id_shop']);
@@ -276,9 +276,9 @@ class Clerk extends Module
             Configuration::updateValue('CLERK_LOGGING_TO', $loggingToValues, false, null, $shop['id_shop']);
 
             Configuration::updateValue('CLERK_CART_EXCLUDE_DUPLICATES', $falseValues, false, null, $shop['id_shop']);
-            Configuration::updateValue('CLERK_POWERSTEP_EXCLUDE_DUPLICATES', $falseValues, false, null, $shop['id_shop']);
+            Configuration::updateValue('CLERK_PWRSTEP_EXCL_DUPLICATES', $falseValues, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_PRODUCT_EXCLUDE_DUPLICATES', $falseValues, false, null, $shop['id_shop']);
-            Configuration::updateValue('CLERK_CATEGORY_EXCLUDE_DUPLICATES', $falseValues, false, null, $shop['id_shop']);
+            Configuration::updateValue('CLERK_CAT_EXCL_DUPLICATES', $falseValues, false, null, $shop['id_shop']);
 
             Configuration::updateValue('CLERK_ADDITIONAL_SCRIPTS_ENABLED', $falseValues, false, null, $shop['id_shop']);
             Configuration::updateValue('CLERK_ADDITIONAL_SCRIPTS_JS', $emptyValues, false, null, $shop['id_shop']);
@@ -443,23 +443,23 @@ class Clerk extends Module
         Configuration::deleteByName('CLERK_LIVESEARCH_TEMPLATE');
         Configuration::deleteByName('CLERK_LIVESEARCH_SELECTOR');
         Configuration::deleteByName('CLERK_LIVESEARCH_FORM_SELECTOR');
-        Configuration::deleteByName('CLERK_LIVESEARCH_NUMBER_SUGGESTIONS');
-        Configuration::deleteByName('CLERK_LIVESEARCH_NUMBER_CATEGORIES');
+        Configuration::deleteByName('CLERK_LS_NUM_SUGGESTIONS');
+        Configuration::deleteByName('CLERK_LS_NUM_CATEGORIES');
         Configuration::deleteByName('CLERK_LIVESEARCH_NUMBER_PAGES');
         Configuration::deleteByName('CLERK_LIVESEARCH_PAGES_TYPE');
-        Configuration::deleteByName('CLERK_LIVESEARCH_DROPDOWN_POSITION');
+        Configuration::deleteByName('CLERK_LS_DROPDOWN_POSITION');
         Configuration::deleteByName('CLERK_POWERSTEP_ENABLED');
         Configuration::deleteByName('CLERK_POWERSTEP_TYPE');
         Configuration::deleteByName('CLERK_POWERSTEP_TEMPLATES');
         Configuration::deleteByName('CLERK_DATASYNC_COLLECT_EMAILS');
         Configuration::deleteByName('CLERK_DATASYNC_COLLECT_BASKETS');
         Configuration::deleteByName('CLERK_DATASYNC_SYNC_SUBSCRIBERS');
-        Configuration::deleteByName('CLERK_DATASYNC_DISABLE_CUSTOMER_SYNC');
-        Configuration::deleteByName('CLERK_DATASYNC_USE_REAL_TIME_UPDATES');
+        Configuration::deleteByName('CLERK_DSYNC_DISABLE_CUST_SYNC');
+        Configuration::deleteByName('CLERK_DSYNC_REALTIME_UPDATES');
         Configuration::deleteByName('CLERK_DATASYNC_PAGE_FIELDS');
         Configuration::deleteByName('CLERK_DATASYNC_INCLUDE_PAGES');
-        Configuration::deleteByName('CLERK_DATASYNC_INCLUDE_OUT_OF_STOCK_PRODUCTS');
-        Configuration::deleteByName('CLERK_DATASYNC_INCLUDE_ONLY_LOCAL_STOCK');
+        Configuration::deleteByName('CLERK_DSYNC_INCL_OOS_PRODUCTS');
+        Configuration::deleteByName('CLERK_DSYNC_ONLY_LOCAL_STOCK');
         Configuration::deleteByName('CLERK_DATASYNC_STATUS_SCOPE_SHOP');
         Configuration::deleteByName('CLERK_DATASYNC_QUERY_BY_STOCK');
         Configuration::deleteByName('CLERK_DATASYNC_CONTEXTUAL_VAT');
@@ -481,9 +481,9 @@ class Clerk extends Module
         Configuration::deleteByName('CLERK_LOGGING_LEVEL');
         Configuration::deleteByName('CLERK_LOGGING_TO');
         Configuration::deleteByName('CLERK_CART_EXCLUDE_DUPLICATES');
-        Configuration::deleteByName('CLERK_POWERSTEP_EXCLUDE_DUPLICATES');
+        Configuration::deleteByName('CLERK_PWRSTEP_EXCL_DUPLICATES');
         Configuration::deleteByName('CLERK_PRODUCT_EXCLUDE_DUPLICATES');
-        Configuration::deleteByName('CLERK_CATEGORY_EXCLUDE_DUPLICATES');
+        Configuration::deleteByName('CLERK_CAT_EXCL_DUPLICATES');
         Configuration::deleteByName('CLERK_ADDITIONAL_SCRIPTS_ENABLED');
         Configuration::deleteByName('CLERK_ADDITIONAL_SCRIPTS_JS');
 
@@ -618,11 +618,11 @@ class Clerk extends Module
                     $this->language_id => Tools::getValue('clerk_livesearch_form_selector', '#search_widget > form')
                 ), false, null, $this->shop_id);
 
-                Configuration::updateValue('CLERK_LIVESEARCH_NUMBER_SUGGESTIONS', array(
+                Configuration::updateValue('CLERK_LS_NUM_SUGGESTIONS', array(
                     $this->language_id => str_replace(' ', '', Tools::getValue('clerk_livesearch_number_suggestions', ''))
                 ), false, null, $this->shop_id);
 
-                Configuration::updateValue('CLERK_LIVESEARCH_NUMBER_CATEGORIES', array(
+                Configuration::updateValue('CLERK_LS_NUM_CATEGORIES', array(
                     $this->language_id => str_replace(' ', '', Tools::getValue('clerk_livesearch_number_categories', ''))
                 ), false, null, $this->shop_id);
 
@@ -634,7 +634,7 @@ class Clerk extends Module
                     $this->language_id => Tools::getValue('clerk_livesearch_pages_type', 'CMS Page')
                 ), false, null, $this->shop_id);
 
-                Configuration::updateValue('CLERK_LIVESEARCH_DROPDOWN_POSITION', array(
+                Configuration::updateValue('CLERK_LS_DROPDOWN_POSITION', array(
                     $this->language_id => Tools::getValue('clerk_livesearch_dropdown_position', 'left')
                 ), false, null, $this->shop_id);
 
@@ -662,11 +662,11 @@ class Clerk extends Module
                     $this->language_id => Tools::getValue('clerk_datasync_sync_subscribers', 1)
                 ), false, null, $this->shop_id);
 
-                Configuration::updateValue('CLERK_DATASYNC_DISABLE_CUSTOMER_SYNC', array(
+                Configuration::updateValue('CLERK_DSYNC_DISABLE_CUST_SYNC', array(
                     $this->language_id => Tools::getValue('clerk_datasync_disable_customer_sync', 1)
                 ), false, null, $this->shop_id);
 
-                Configuration::updateValue('CLERK_DATASYNC_USE_REAL_TIME_UPDATES', array(
+                Configuration::updateValue('CLERK_DSYNC_REALTIME_UPDATES', array(
                     $this->language_id => Tools::getValue('clerk_datasync_use_real_time_updates', 1)
                 ), false, null, $this->shop_id);
 
@@ -678,11 +678,11 @@ class Clerk extends Module
                     $this->language_id => Tools::getValue('clerk_datasync_include_pages', 1)
                 ), false, null, $this->shop_id);
 
-                Configuration::updateValue('CLERK_DATASYNC_INCLUDE_OUT_OF_STOCK_PRODUCTS', array(
+                Configuration::updateValue('CLERK_DSYNC_INCL_OOS_PRODUCTS', array(
                     $this->language_id => Tools::getValue('clerk_datasync_include_out_of_stock_products', 0)
                 ), false, null, $this->shop_id);
 
-                Configuration::updateValue('CLERK_DATASYNC_INCLUDE_ONLY_LOCAL_STOCK', array(
+                Configuration::updateValue('CLERK_DSYNC_ONLY_LOCAL_STOCK', array(
                     $this->language_id => Tools::getValue('clerk_datasync_include_only_local_stock', 0)
                 ), false, null, $this->shop_id);
 
@@ -768,7 +768,7 @@ class Clerk extends Module
                     $this->language_id => Tools::getValue('clerk_cart_exclude_duplicates', 0)
                 ), false, null, $this->shop_id);
 
-                Configuration::updateValue('CLERK_POWERSTEP_EXCLUDE_DUPLICATES', array(
+                Configuration::updateValue('CLERK_PWRSTEP_EXCL_DUPLICATES', array(
                     $this->language_id => Tools::getValue('clerk_powerstep_exclude_duplicates', 0)
                 ), false, null, $this->shop_id);
 
@@ -776,7 +776,7 @@ class Clerk extends Module
                     $this->language_id => Tools::getValue('clerk_product_exclude_duplicates', 0)
                 ), false, null, $this->shop_id);
 
-                Configuration::updateValue('CLERK_CATEGORY_EXCLUDE_DUPLICATES', array(
+                Configuration::updateValue('CLERK_CAT_EXCL_DUPLICATES', array(
                     $this->language_id => Tools::getValue('clerk_category_exclude_duplicates', 0)
                 ), false, null, $this->shop_id);
 
@@ -809,9 +809,9 @@ class Clerk extends Module
 
             $powerstep_initiated = Configuration::get('CLERK_LOGGING_POWERSTEPFIRST', $this->language_id, null, $this->shop_id);
 
-            $datasync_collect_emails_initiated = Configuration::get('CLERK_LOGGING_DATASYNC_COLLECT_EMAILS', $this->language_id, null, $this->shop_id);
+            $datasync_collect_emails_initiated = Configuration::get('CLERK_LOG_DSYNC_COLLECT_EMAILS', $this->language_id, null, $this->shop_id);
 
-            $datasync_disable_order_synchronization_initiated = Configuration::get('CLERK_LOGGING_DATASYNC_DISABLE_ORDER_SYNCHRONIZATION', $this->language_id, null, $this->shop_id);
+            $datasync_disable_order_synchronization_initiated = Configuration::get('CLERK_LOG_DSYNC_NO_ORDER_SYNC', $this->language_id, null, $this->shop_id);
 
             $exit_intent_initiated = Configuration::get('CLERK_LOGGING_EXIT_INTENT', $this->language_id, null, $this->shop_id);
 
@@ -851,7 +851,7 @@ class Clerk extends Module
 
             if ($datasync_disable_order_synchronization_enabled == '1' && $datasync_disable_order_synchronization_initiated !== '1') {
 
-                Configuration::updateValue('CLERK_LOGGING_DATASYNC_DISABLE_ORDER_SYNCHRONIZATION', array(
+                Configuration::updateValue('CLERK_LOG_DSYNC_NO_ORDER_SYNC', array(
                     $this->language_id => 1
                 ), false, null, $this->shop_id);
 
@@ -860,7 +860,7 @@ class Clerk extends Module
 
             if ($datasync_disable_order_synchronization_enabled !== '1' && $datasync_disable_order_synchronization_initiated == '1') {
 
-                Configuration::updateValue('CLERK_LOGGING_DATASYNC_DISABLE_ORDER_SYNCHRONIZATION', array(
+                Configuration::updateValue('CLERK_LOG_DSYNC_NO_ORDER_SYNC', array(
                     $this->language_id => 0
                 ), false, null, $this->shop_id);
 
@@ -869,7 +869,7 @@ class Clerk extends Module
 
             if ($datasync_collect_emails_enabled == '1' && $datasync_collect_emails_initiated !== '1') {
 
-                Configuration::updateValue('CLERK_LOGGING_DATASYNC_COLLECT_EMAILS', array(
+                Configuration::updateValue('CLERK_LOG_DSYNC_COLLECT_EMAILS', array(
                     $this->language_id => 1
                 ), false, null, $this->shop_id);
 
@@ -878,7 +878,7 @@ class Clerk extends Module
 
             if ($datasync_collect_emails_enabled !== '1' && $datasync_collect_emails_initiated == '1') {
 
-                Configuration::updateValue('CLERK_LOGGING_DATASYNC_COLLECT_EMAILS', array(
+                Configuration::updateValue('CLERK_LOG_DSYNC_COLLECT_EMAILS', array(
                     $this->language_id => 0
                 ), false, null, $this->shop_id);
 
@@ -2821,23 +2821,23 @@ CLERKJS;
             'clerk_livesearch_template' => Configuration::get('CLERK_LIVESEARCH_TEMPLATE', $_lang_id, null, $_shop_id),
             'clerk_livesearch_selector' => Configuration::get('CLERK_LIVESEARCH_SELECTOR', $_lang_id, null, $_shop_id),
             'clerk_livesearch_form_selector' => Configuration::get('CLERK_LIVESEARCH_FORM_SELECTOR', $_lang_id, null, $_shop_id),
-            'clerk_livesearch_number_suggestions' => Configuration::get('CLERK_LIVESEARCH_NUMBER_SUGGESTIONS', $_lang_id, null, $_shop_id),
-            'clerk_livesearch_number_categories' => Configuration::get('CLERK_LIVESEARCH_NUMBER_CATEGORIES', $_lang_id, null, $_shop_id),
+            'clerk_livesearch_number_suggestions' => Configuration::get('CLERK_LS_NUM_SUGGESTIONS', $_lang_id, null, $_shop_id),
+            'clerk_livesearch_number_categories' => Configuration::get('CLERK_LS_NUM_CATEGORIES', $_lang_id, null, $_shop_id),
             'clerk_livesearch_number_pages' => Configuration::get('CLERK_LIVESEARCH_NUMBER_PAGES', $_lang_id, null, $_shop_id),
             'clerk_livesearch_pages_type' => Configuration::get('CLERK_LIVESEARCH_PAGES_TYPE', $_lang_id, null, $_shop_id),
-            'clerk_livesearch_dropdown_position' => Configuration::get('CLERK_LIVESEARCH_DROPDOWN_POSITION', $_lang_id, null, $_shop_id),
+            'clerk_livesearch_dropdown_position' => Configuration::get('CLERK_LS_DROPDOWN_POSITION', $_lang_id, null, $_shop_id),
             'clerk_powerstep_enabled' => Configuration::get('CLERK_POWERSTEP_ENABLED', $_lang_id, null, $_shop_id),
             'clerk_powerstep_type' => Configuration::get('CLERK_POWERSTEP_TYPE', $_lang_id, null, $_shop_id),
             'clerk_powerstep_templates' => Configuration::get('CLERK_POWERSTEP_TEMPLATES', $_lang_id, null, $_shop_id),
             'clerk_datasync_collect_emails' => Configuration::get('CLERK_DATASYNC_COLLECT_EMAILS', $_lang_id, null, $_shop_id),
             'clerk_datasync_collect_baskets' => Configuration::get('CLERK_DATASYNC_COLLECT_BASKETS', $_lang_id, null, $_shop_id),
             'clerk_datasync_sync_subscribers' => Configuration::get('CLERK_DATASYNC_SYNC_SUBSCRIBERS', $_lang_id, null, $_shop_id),
-            'clerk_datasync_disable_customer_sync' => Configuration::get('CLERK_DATASYNC_DISABLE_CUSTOMER_SYNC', $_lang_id, null, $_shop_id),
-            'clerk_datasync_use_real_time_updates' => Configuration::get('CLERK_DATASYNC_USE_REAL_TIME_UPDATES', $_lang_id, null, $_shop_id),
+            'clerk_datasync_disable_customer_sync' => Configuration::get('CLERK_DSYNC_DISABLE_CUST_SYNC', $_lang_id, null, $_shop_id),
+            'clerk_datasync_use_real_time_updates' => Configuration::get('CLERK_DSYNC_REALTIME_UPDATES', $_lang_id, null, $_shop_id),
             'clerk_datasync_include_pages' => Configuration::get('CLERK_DATASYNC_INCLUDE_PAGES', $_lang_id, null, $_shop_id),
             'clerk_datasync_page_fields' => Configuration::get('CLERK_DATASYNC_PAGE_FIELDS', $_lang_id, null, $_shop_id),
-            'clerk_datasync_include_out_of_stock_products' => Configuration::get('CLERK_DATASYNC_INCLUDE_OUT_OF_STOCK_PRODUCTS', $_lang_id, null, $_shop_id),
-            'clerk_datasync_include_only_local_stock' => Configuration::get('CLERK_DATASYNC_INCLUDE_ONLY_LOCAL_STOCK', $_lang_id, null, $_shop_id),
+            'clerk_datasync_include_out_of_stock_products' => Configuration::get('CLERK_DSYNC_INCL_OOS_PRODUCTS', $_lang_id, null, $_shop_id),
+            'clerk_datasync_include_only_local_stock' => Configuration::get('CLERK_DSYNC_ONLY_LOCAL_STOCK', $_lang_id, null, $_shop_id),
             'clerk_datasync_status_scope_shop' => Configuration::get('CLERK_DATASYNC_STATUS_SCOPE_SHOP', $_lang_id, null, $_shop_id),
             'clerk_datasync_contextual_vat' => Configuration::get('CLERK_DATASYNC_CONTEXTUAL_VAT', $_lang_id, null, $_shop_id),
             'clerk_datasync_query_by_stock' => Configuration::get('CLERK_DATASYNC_QUERY_BY_STOCK', $_lang_id, null, $_shop_id),
@@ -2859,9 +2859,9 @@ CLERKJS;
             'clerk_logging_level' => Configuration::get('CLERK_LOGGING_LEVEL', $_lang_id, null, $_shop_id),
             'clerk_logging_to' => Configuration::get('CLERK_LOGGING_TO', $_lang_id, null, $_shop_id),
             'clerk_cart_exclude_duplicates' => Configuration::get('CLERK_CART_EXCLUDE_DUPLICATES', $_lang_id, null, $_shop_id),
-            'clerk_powerstep_exclude_duplicates' => Configuration::get('CLERK_POWERSTEP_EXCLUDE_DUPLICATES', $_lang_id, null, $_shop_id),
+            'clerk_powerstep_exclude_duplicates' => Configuration::get('CLERK_PWRSTEP_EXCL_DUPLICATES', $_lang_id, null, $_shop_id),
             'clerk_product_exclude_duplicates' => Configuration::get('CLERK_PRODUCT_EXCLUDE_DUPLICATES', $_lang_id, null, $_shop_id),
-            'clerk_category_exclude_duplicates' => Configuration::get('CLERK_CATEGORY_EXCLUDE_DUPLICATES', $_lang_id, null, $_shop_id),
+            'clerk_category_exclude_duplicates' => Configuration::get('CLERK_CAT_EXCL_DUPLICATES', $_lang_id, null, $_shop_id),
             'clerk_additional_scripts_enabled' => Configuration::get('CLERK_ADDITIONAL_SCRIPTS_ENABLED', $_lang_id, null, $_shop_id),
             'clerk_additional_scripts_js' => Configuration::get('CLERK_ADDITIONAL_SCRIPTS_JS', $_lang_id, null, $_shop_id),
         );
@@ -3012,11 +3012,11 @@ CLERKJS;
                         'search_query' => (string) Tools::getValue('search_query', ''),
                         'livesearch_enabled' => (bool) Configuration::get('CLERK_LIVESEARCH_ENABLED', $this->context->language->id, null, $this->context->shop->id),
                         'livesearch_categories' => (int) Configuration::get('CLERK_LIVESEARCH_CATEGORIES', $this->context->language->id, null, $this->context->shop->id),
-                        'livesearch_number_categories' => (int) Configuration::get('CLERK_LIVESEARCH_NUMBER_CATEGORIES', $this->context->language->id, null, $this->context->shop->id),
-                        'livesearch_number_suggestions' => (int) Configuration::get('CLERK_LIVESEARCH_NUMBER_SUGGESTIONS', $this->context->language->id, null, $this->context->shop->id),
+                        'livesearch_number_categories' => (int) Configuration::get('CLERK_LS_NUM_CATEGORIES', $this->context->language->id, null, $this->context->shop->id),
+                        'livesearch_number_suggestions' => (int) Configuration::get('CLERK_LS_NUM_SUGGESTIONS', $this->context->language->id, null, $this->context->shop->id),
                         'livesearch_number_pages' => (int) Configuration::get('CLERK_LIVESEARCH_NUMBER_PAGES', $this->context->language->id, null, $this->context->shop->id),
                         'livesearch_pages_type' => (string) Configuration::get('CLERK_LIVESEARCH_PAGES_TYPE', $this->context->language->id, null, $this->context->shop->id),
-                        'livesearch_dropdown_position' => (string) Configuration::get('CLERK_LIVESEARCH_DROPDOWN_POSITION', $this->context->language->id, null, $this->context->shop->id),
+                        'livesearch_dropdown_position' => (string) Configuration::get('CLERK_LS_DROPDOWN_POSITION', $this->context->language->id, null, $this->context->shop->id),
                         'search_enabled' => (bool) Configuration::get('CLERK_SEARCH_ENABLED', $this->context->language->id, null, $this->context->shop->id),
                         'livesearch_selector' => Configuration::get('CLERK_LIVESEARCH_SELECTOR', $this->context->language->id, null, $this->context->shop->id),
                         'livesearch_form_selector' => htmlspecialchars_decode(Configuration::get('CLERK_LIVESEARCH_FORM_SELECTOR', $this->context->language->id, null, $this->context->shop->id)),
@@ -3036,7 +3036,7 @@ CLERKJS;
 
                         $Contents = explode(',', Configuration::get('CLERK_POWERSTEP_TEMPLATES', $this->context->language->id, null, $this->context->shop->id));
 
-                        $exclude_duplicates_powerstep = (bool) Configuration::get('CLERK_POWERSTEP_EXCLUDE_DUPLICATES', $context->language->id, null, $this->context->shop->id);
+                        $exclude_duplicates_powerstep = (bool) Configuration::get('CLERK_PWRSTEP_EXCL_DUPLICATES', $context->language->id, null, $this->context->shop->id);
 
                         $this->context->smarty->assign(
                             array(
@@ -3054,7 +3054,7 @@ CLERKJS;
                     if ($category_id) {
                         $Contents = explode(',', Configuration::get('CLERK_CATEGORY_TEMPLATE', $this->context->language->id, null, $this->context->shop->id));
 
-                        $exclude_duplicates_category = (bool) Configuration::get('CLERK_CATEGORY_EXCLUDE_DUPLICATES', $context->language->id, null, $this->context->shop->id);
+                        $exclude_duplicates_category = (bool) Configuration::get('CLERK_CAT_EXCL_DUPLICATES', $context->language->id, null, $this->context->shop->id);
 
                         $this->context->smarty->assign(
                             array(
@@ -3102,7 +3102,7 @@ CLERKJS;
                     $templatesConfig = Configuration::get('CLERK_POWERSTEP_TEMPLATES', $this->context->language->id, null, $this->context->shop->id);
                     $templates = array_filter(explode(',', $templatesConfig));
 
-                    $exclude_duplicates_powerstep = (bool) Configuration::get('CLERK_POWERSTEP_EXCLUDE_DUPLICATES', $this->context->language->id, null, $this->context->shop->id);
+                    $exclude_duplicates_powerstep = (bool) Configuration::get('CLERK_PWRSTEP_EXCL_DUPLICATES', $this->context->language->id, null, $this->context->shop->id);
 
                     $categories = $product->getCategories();
                     $category = reset($categories);
@@ -3158,9 +3158,9 @@ CLERKJS;
         $this->context->smarty->assign(
             array(
                 'clerk_public_key' => Configuration::get('CLERK_PUBLIC_KEY', $this->context->language->id, null, $this->context->shop->id),
-                'clerk_datasync_use_real_time_updates' => Configuration::get('CLERK_DATASYNC_USE_REAL_TIME_UPDATES', $this->context->language->id, null, $this->context->shop->id),
-                'clerk_datasync_include_out_of_stock_products' => Configuration::get('CLERK_DATASYNC_INCLUDE_OUT_OF_STOCK_PRODUCTS', $this->context->language->id, null, $this->context->shop->id),
-                'clerk_datasync_include_only_local_stock' => Configuration::get('CLERK_DATASYNC_INCLUDE_ONLY_LOCAL_STOCK', $this->context->language->id, null, $this->context->shop->id),
+                'clerk_datasync_use_real_time_updates' => Configuration::get('CLERK_DSYNC_REALTIME_UPDATES', $this->context->language->id, null, $this->context->shop->id),
+                'clerk_datasync_include_out_of_stock_products' => Configuration::get('CLERK_DSYNC_INCL_OOS_PRODUCTS', $this->context->language->id, null, $this->context->shop->id),
+                'clerk_datasync_include_only_local_stock' => Configuration::get('CLERK_DSYNC_ONLY_LOCAL_STOCK', $this->context->language->id, null, $this->context->shop->id),
                 'clerk_datasync_status_scope_shop' => Configuration::get('CLERK_DATASYNC_STATUS_SCOPE_SHOP', $this->context->language->id, null, $this->context->shop->id),
                 'clerk_datasync_query_by_stock' => Configuration::get('CLERK_DATASYNC_QUERY_BY_STOCK', $this->context->language->id, null, $this->context->shop->id),
                 'clerk_datasync_contextual_vat' => Configuration::get('CLERK_DATASYNC_CONTEXTUAL_VAT', $this->context->language->id, null, $this->context->shop->id),
@@ -3182,9 +3182,9 @@ CLERKJS;
                 'clerk_logging_to' => Configuration::get('CLERK_LOGGING_TO', $this->context->language->id, null, $this->context->shop->id),
                 'clerk_collect_cart' => Configuration::get('CLERK_DATASYNC_COLLECT_BASKETS', $this->context->language->id, null, $this->context->shop->id),
                 'clerk_cart_exclude_duplicates' => (bool) Configuration::get('CLERK_CART_EXCLUDE_DUPLICATES', $this->context->language->id, null, $this->context->shop->id),
-                'clerk_powerstep_exclude_duplicates' => (bool) Configuration::get('CLERK_POWERSTEP_EXCLUDE_DUPLICATES', $this->context->language->id, null, $this->context->shop->id),
+                'clerk_powerstep_exclude_duplicates' => (bool) Configuration::get('CLERK_PWRSTEP_EXCL_DUPLICATES', $this->context->language->id, null, $this->context->shop->id),
                 'clerk_product_exclude_duplicates' => (bool) Configuration::get('CLERK_PRODUCT_EXCLUDE_DUPLICATES', $this->context->language->id, null, $this->context->shop->id),
-                'clerk_category_exclude_duplicates' => (bool) Configuration::get('CLERK_CATEGORY_EXCLUDE_DUPLICATES', $this->context->language->id, null, $this->context->shop->id),
+                'clerk_category_exclude_duplicates' => (bool) Configuration::get('CLERK_CAT_EXCL_DUPLICATES', $this->context->language->id, null, $this->context->shop->id),
                 'clerk_cart_update' => $clerk_cart_update,
                 'clerk_cart_products' => $clerk_cart_products,
                 'templates' => $templates,
@@ -3251,7 +3251,7 @@ CLERKJS;
 
             $Contents = explode(',', Configuration::get('CLERK_CATEGORY_TEMPLATE', $this->context->language->id, null, $this->context->shop->id));
 
-            $exclude_duplicates_category = (bool) Configuration::get('CLERK_CATEGORY_EXCLUDE_DUPLICATES', $this->context->language->id, null, $this->context->shop->id);
+            $exclude_duplicates_category = (bool) Configuration::get('CLERK_CAT_EXCL_DUPLICATES', $this->context->language->id, null, $this->context->shop->id);
 
             $category_id = Tools::getValue("id_category");
 
@@ -3303,7 +3303,7 @@ CLERKJS;
         $enabled = (bool) Configuration::get('CLERK_POWERSTEP_ENABLED', $context->language->id, null, $this->context->shop->id);
         $type = (string) Configuration::get('CLERK_POWERSTEP_TYPE', $context->language->id, null, $this->context->shop->id);
 
-        $exclude_duplicates_powerstep = (bool) Configuration::get('CLERK_POWERSTEP_EXCLUDE_DUPLICATES', $this->context->language->id, null, $this->context->shop->id);
+        $exclude_duplicates_powerstep = (bool) Configuration::get('CLERK_PWRSTEP_EXCL_DUPLICATES', $this->context->language->id, null, $this->context->shop->id);
 
         if (version_compare(_PS_VERSION_, '1.7.0', '>=')) {
             $Contents = explode(',', Configuration::get('CLERK_POWERSTEP_TEMPLATES', $this->context->language->id, null, $this->context->shop->id));
@@ -3488,7 +3488,7 @@ CLERKJS;
 
         $contentConfig = Configuration::get('CLERK_POWERSTEP_TEMPLATES', $this->context->language->id, null, $this->context->shop->id);
         $contents = array_filter(explode(',', $contentConfig));
-        $exclude_duplicates_powerstep = (bool) Configuration::get('CLERK_POWERSTEP_EXCLUDE_DUPLICATES', $this->context->language->id, null, $this->context->shop->id);
+        $exclude_duplicates_powerstep = (bool) Configuration::get('CLERK_PWRSTEP_EXCL_DUPLICATES', $this->context->language->id, null, $this->context->shop->id);
 
         foreach ($contents as $key => $content) {
 
@@ -3692,11 +3692,11 @@ CLERKJS;
                     'search_query' => (string) Tools::getValue('search_query', ''),
                     'livesearch_enabled' => (bool) Configuration::get('CLERK_LIVESEARCH_ENABLED', $this->context->language->id, null, $this->context->shop->id),
                     'livesearch_categories' => (int) Configuration::get('CLERK_LIVESEARCH_CATEGORIES', $this->context->language->id, null, $this->context->shop->id),
-                    'livesearch_number_categories' => (int) Configuration::get('CLERK_LIVESEARCH_NUMBER_CATEGORIES', $this->context->language->id, null, $this->context->shop->id),
-                    'livesearch_number_suggestions' => (int) Configuration::get('CLERK_LIVESEARCH_NUMBER_SUGGESTIONS', $this->context->language->id, null, $this->context->shop->id),
+                    'livesearch_number_categories' => (int) Configuration::get('CLERK_LS_NUM_CATEGORIES', $this->context->language->id, null, $this->context->shop->id),
+                    'livesearch_number_suggestions' => (int) Configuration::get('CLERK_LS_NUM_SUGGESTIONS', $this->context->language->id, null, $this->context->shop->id),
                     'livesearch_number_pages' => (int) Configuration::get('CLERK_LIVESEARCH_NUMBER_PAGES', $this->context->language->id, null, $this->context->shop->id),
                     'livesearch_pages_type' => (string) Configuration::get('CLERK_LIVESEARCH_PAGES_TYPE', $this->context->language->id, null, $this->context->shop->id),
-                    'livesearch_dropdown_position' => (string) Configuration::get('CLERK_LIVESEARCH_DROPDOWN_POSITION', $this->context->language->id, null, $this->context->shop->id),
+                    'livesearch_dropdown_position' => (string) Configuration::get('CLERK_LS_DROPDOWN_POSITION', $this->context->language->id, null, $this->context->shop->id),
                     'search_enabled' => (bool) Configuration::get('CLERK_SEARCH_ENABLED', $this->context->language->id, null, $this->context->shop->id),
                     'livesearch_selector' => Configuration::get('CLERK_LIVESEARCH_SELECTOR', $this->context->language->id, null, $this->context->shop->id),
                     'livesearch_form_selector' => htmlspecialchars_decode(Configuration::get('CLERK_LIVESEARCH_FORM_SELECTOR', $this->context->language->id, null, $this->context->shop->id)),
@@ -3716,7 +3716,7 @@ CLERKJS;
 
                     $Contents = explode(',', Configuration::get('CLERK_POWERSTEP_TEMPLATES', $this->context->language->id, null, $this->context->shop->id));
 
-                    $exclude_duplicates_powerstep = (bool) Configuration::get('CLERK_POWERSTEP_EXCLUDE_DUPLICATES', $context->language->id, null, $this->context->shop->id);
+                    $exclude_duplicates_powerstep = (bool) Configuration::get('CLERK_PWRSTEP_EXCL_DUPLICATES', $context->language->id, null, $this->context->shop->id);
 
                     $this->context->smarty->assign(
                         array(
@@ -3734,7 +3734,7 @@ CLERKJS;
                 if ($category_id) {
                     $Contents = explode(',', Configuration::get('CLERK_CATEGORY_TEMPLATE', $this->context->language->id, null, $this->context->shop->id));
 
-                    $exclude_duplicates_category = (bool) Configuration::get('CLERK_CATEGORY_EXCLUDE_DUPLICATES', $context->language->id, null, $this->context->shop->id);
+                    $exclude_duplicates_category = (bool) Configuration::get('CLERK_CAT_EXCL_DUPLICATES', $context->language->id, null, $this->context->shop->id);
 
                     $this->context->smarty->assign(
                         array(

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>clerk</name>
     <displayName><![CDATA[Clerk]]></displayName>
-    <version><![CDATA[6.9.2]]></version>
+    <version><![CDATA[6.9.3]]></version>
     <description><![CDATA[Clerk.io Turns More Browsers Into Buyers]]></description>
     <author><![CDATA[Clerk]]></author>
     <tab><![CDATA[advertising_marketing]]></tab>

--- a/config_da.xml
+++ b/config_da.xml
@@ -2,7 +2,7 @@
 <module>
     <name>clerk</name>
     <displayName><![CDATA[Clerk]]></displayName>
-    <version><![CDATA[6.9.2]]></version>
+    <version><![CDATA[6.9.3]]></version>
     <description><![CDATA[Clerk.io Turns More Browsers Into Buyers]]></description>
     <author><![CDATA[Clerk]]></author>
     <tab><![CDATA[advertising_marketing]]></tab>

--- a/config_de.xml
+++ b/config_de.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>clerk</name>
 	<displayName><![CDATA[Clerk]]></displayName>
-	<version><![CDATA[6.9.2]]></version>
+	<version><![CDATA[6.9.3]]></version>
 	<description><![CDATA[Clerk.io Turns More Browsers Into Buyers]]></description>
 	<author><![CDATA[Clerk]]></author>
 	<tab><![CDATA[advertising_marketing]]></tab>

--- a/config_fr.xml
+++ b/config_fr.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>clerk</name>
 	<displayName><![CDATA[Clerk]]></displayName>
-	<version><![CDATA[6.9.2]]></version>
+	<version><![CDATA[6.9.3]]></version>
 	<description><![CDATA[Clerk.io Turns More Browsers Into Buyers]]></description>
 	<author><![CDATA[Clerk]]></author>
 	<tab><![CDATA[advertising_marketing]]></tab>

--- a/config_it.xml
+++ b/config_it.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>clerk</name>
 	<displayName><![CDATA[Clerk]]></displayName>
-	<version><![CDATA[6.9.2]]></version>
+	<version><![CDATA[6.9.3]]></version>
 	<description><![CDATA[Clerk.io Turns More Browsers Into Buyers]]></description>
 	<author><![CDATA[Clerk]]></author>
 	<tab><![CDATA[advertising_marketing]]></tab>

--- a/controllers/front/added.php
+++ b/controllers/front/added.php
@@ -70,7 +70,7 @@ class ClerkAddedModuleFrontController extends ModuleFrontController
             Tools::redirect('index.php');
         }
 
-        $exclude_duplicates_powerstep = (bool)Configuration::get('CLERK_POWERSTEP_EXCLUDE_DUPLICATES', $this->context->language->id, null, $this->context->shop->id);
+        $exclude_duplicates_powerstep = (bool)Configuration::get('CLERK_PWRSTEP_EXCL_DUPLICATES', $this->context->language->id, null, $this->context->shop->id);
 
         $image = Image::getCover($id_product);
 

--- a/controllers/front/customer.php
+++ b/controllers/front/customer.php
@@ -48,7 +48,7 @@ class ClerkCustomerModuleFrontController extends ClerkAbstractFrontController
         try {
             header('User-Agent: ClerkExtensionBot Prestashop/v' . _PS_VERSION_ . ' Clerk/v' . Module::getInstanceByName('clerk')->version . ' PHP/v' . phpversion());
 
-            if (Configuration::get('CLERK_DATASYNC_DISABLE_CUSTOMER_SYNC',  $this->getLanguageId(), null, $this->getShopId()) == '1') {
+            if (Configuration::get('CLERK_DSYNC_DISABLE_CUST_SYNC',  $this->getLanguageId(), null, $this->getShopId()) == '1') {
                 return [];
             }
 

--- a/controllers/front/getconfig.php
+++ b/controllers/front/getconfig.php
@@ -66,11 +66,11 @@ class ClerkGetConfigModuleFrontController extends ClerkAbstractFrontController
             'clerk_tracking_hook_position' => Configuration::get('CLERK_TRACKING_HOOK_POSITION', $this->context->language->id, null, $this->shop_id),
 
             // DATA-SYNC SETTINGS (10)
-            'clerk_datasync_use_real_time_updates' => Configuration::get('CLERK_DATASYNC_USE_REAL_TIME_UPDATES', $this->context->language->id, null, $this->shop_id),
+            'clerk_datasync_use_real_time_updates' => Configuration::get('CLERK_DSYNC_REALTIME_UPDATES', $this->context->language->id, null, $this->shop_id),
             'clerk_datasync_include_pages' => Configuration::get('CLERK_DATASYNC_INCLUDE_PAGES', $this->context->language->id, null, $this->shop_id),
             'clerk_datasync_page_fields' => Configuration::get('CLERK_DATASYNC_PAGE_FIELDS', $this->context->language->id, null, $this->shop_id),
-            'clerk_datasync_include_out_of_stock_products' => Configuration::get('CLERK_DATASYNC_INCLUDE_OUT_OF_STOCK_PRODUCTS', $this->context->language->id, null, $this->shop_id),
-            'clerk_datasync_include_only_local_stock' => Configuration::get('CLERK_DATASYNC_INCLUDE_ONLY_LOCAL_STOCK', $this->context->language->id, null, $this->shop_id),
+            'clerk_datasync_include_out_of_stock_products' => Configuration::get('CLERK_DSYNC_INCL_OOS_PRODUCTS', $this->context->language->id, null, $this->shop_id),
+            'clerk_datasync_include_only_local_stock' => Configuration::get('CLERK_DSYNC_ONLY_LOCAL_STOCK', $this->context->language->id, null, $this->shop_id),
             'clerk_datasync_status_scope_shop' => Configuration::get('CLERK_DATASYNC_STATUS_SCOPE_SHOP', $this->context->language->id, null, $this->shop_id),
             'clerk_datasync_collect_emails' => Configuration::get('CLERK_DATASYNC_COLLECT_EMAILS', $this->language_id, null, $this->shop_id),
             'clerk_datasync_collect_baskets' => Configuration::get('CLERK_DATASYNC_COLLECT_BASKETS', $this->language_id, null, $this->shop_id),
@@ -82,7 +82,7 @@ class ClerkGetConfigModuleFrontController extends ClerkAbstractFrontController
             'clerk_datasync_product_tags' => Configuration::get('CLERK_DATASYNC_PRODUCT_TAGS', $this->language_id, null, $this->shop_id),
             'clerk_image_size' => Configuration::get('CLERK_IMAGE_SIZE', $this->language_id, null, $this->shop_id),
             'clerk_datasync_query_by_stock' => Configuration::get('CLERK_DATASYNC_QUERY_BY_STOCK', $this->language_id, null, $this->shop_id),
-            'clerk_datasync_disable_customer_sync' => Configuration::get('CLERK_DATASYNC_DISABLE_CUSTOMER_SYNC', $this->language_id, null, $this->shop_id),
+            'clerk_datasync_disable_customer_sync' => Configuration::get('CLERK_DSYNC_DISABLE_CUST_SYNC', $this->language_id, null, $this->shop_id),
 
             // SEARCH SETTINGS (6)
             'clerk_search_enabled' => Configuration::get('CLERK_SEARCH_ENABLED', $this->language_id, null, $this->shop_id),
@@ -105,11 +105,11 @@ class ClerkGetConfigModuleFrontController extends ClerkAbstractFrontController
             'clerk_livesearch_template' => Configuration::get('CLERK_LIVESEARCH_TEMPLATE', $this->language_id, null, $this->shop_id),
             'clerk_livesearch_selector' => Configuration::get('CLERK_LIVESEARCH_SELECTOR', $this->language_id, null, $this->shop_id),
             'clerk_livesearch_form_selector' => Configuration::get('CLERK_LIVESEARCH_FORM_SELECTOR', $this->language_id, null, $this->shop_id),
-            'clerk_livesearch_number_suggestions' => Configuration::get('CLERK_LIVESEARCH_NUMBER_SUGGESTIONS', $this->language_id, null, $this->shop_id),
-            'clerk_livesearch_number_categories' => Configuration::get('CLERK_LIVESEARCH_NUMBER_CATEGORIES', $this->language_id, null, $this->shop_id),
+            'clerk_livesearch_number_suggestions' => Configuration::get('CLERK_LS_NUM_SUGGESTIONS', $this->language_id, null, $this->shop_id),
+            'clerk_livesearch_number_categories' => Configuration::get('CLERK_LS_NUM_CATEGORIES', $this->language_id, null, $this->shop_id),
             'clerk_livesearch_number_pages' => Configuration::get('CLERK_LIVESEARCH_NUMBER_PAGES', $this->language_id, null, $this->shop_id),
             'clerk_livesearch_pages_type' => Configuration::get('CLERK_LIVESEARCH_PAGES_TYPE', $this->language_id, null, $this->shop_id),
-            'clerk_livesearch_dropdown_position' => Configuration::get('CLERK_LIVESEARCH_DROPDOWN_POSITION', $this->language_id, null, $this->shop_id),
+            'clerk_livesearch_dropdown_position' => Configuration::get('CLERK_LS_DROPDOWN_POSITION', $this->language_id, null, $this->shop_id),
 
             // POWERSTEP SETTINGS (3)
             'clerk_powerstep_enabled' => Configuration::get('CLERK_POWERSTEP_ENABLED', $this->language_id, null, $this->shop_id),
@@ -139,9 +139,9 @@ class ClerkGetConfigModuleFrontController extends ClerkAbstractFrontController
 
 
             'clerk_cart_exclude_duplicates' => Configuration::get('CLERK_CART_EXCLUDE_DUPLICATES', $this->language_id, null, $this->shop_id),
-            'clerk_powerstep_exclude_duplicates' => Configuration::get('CLERK_POWERSTEP_EXCLUDE_DUPLICATES', $this->language_id, null, $this->shop_id),
+            'clerk_powerstep_exclude_duplicates' => Configuration::get('CLERK_PWRSTEP_EXCL_DUPLICATES', $this->language_id, null, $this->shop_id),
             'clerk_product_exclude_duplicates' => Configuration::get('CLERK_PRODUCT_EXCLUDE_DUPLICATES', $this->language_id, null, $this->shop_id),
-            'clerk_category_exclude_duplicates' => Configuration::get('CLERK_CATEGORY_EXCLUDE_DUPLICATES', $this->language_id, null, $this->shop_id),
+            'clerk_category_exclude_duplicates' => Configuration::get('CLERK_CAT_EXCL_DUPLICATES', $this->language_id, null, $this->shop_id),
 
 
             'clerk_additional_scripts_enabled' => Configuration::get('CLERK_ADDITIONAL_SCRIPTS_ENABLED', $this->language_id, null, $this->shop_id),

--- a/controllers/front/powerstep.php
+++ b/controllers/front/powerstep.php
@@ -66,7 +66,7 @@ class ClerkPowerstepModuleFrontController extends ModuleFrontController
 
             }
 
-            $exclude_duplicates_powerstep = (bool)Configuration::get('CLERK_POWERSTEP_EXCLUDE_DUPLICATES', $this->context->language->id, null, $this->context->shop->id);
+            $exclude_duplicates_powerstep = (bool)Configuration::get('CLERK_PWRSTEP_EXCL_DUPLICATES', $this->context->language->id, null, $this->context->shop->id);
 
             $categories = $product->getCategories();
             $category = reset($categories);

--- a/controllers/front/product.php
+++ b/controllers/front/product.php
@@ -164,7 +164,7 @@ class ClerkProductModuleFrontController extends ClerkAbstractFrontController
             $active = ' AND p.active = 1';
         }
 
-        if (Configuration::get('CLERK_DATASYNC_INCLUDE_ONLY_LOCAL_STOCK', $language_id, null, $shop_id)) {
+        if (Configuration::get('CLERK_DSYNC_ONLY_LOCAL_STOCK', $language_id, null, $shop_id)) {
             $active .= ' AND ((ps.available_for_order IS NULL AND p.available_for_order = 1) OR (p.available_for_order IS NULL AND ps.available_for_order = 1) OR (p.available_for_order = 1 AND ps.available_for_order = 1))';
         }
 

--- a/controllers/front/setconfig.php
+++ b/controllers/front/setconfig.php
@@ -72,7 +72,7 @@ class ClerkSetConfigModuleFrontController extends ClerkAbstractFrontController
 
             // DATA-SYNC SETTINGS (10)
             if ($key == "clerk_datasync_use_real_time_updates") {
-                Configuration::updateValue('CLERK_DATASYNC_USE_REAL_TIME_UPDATES', array($this->language_id => $value), false, null, $this->shop_id);
+                Configuration::updateValue('CLERK_DSYNC_REALTIME_UPDATES', array($this->language_id => $value), false, null, $this->shop_id);
             }
             if ($key == "clerk_datasync_include_pages") {
                 Configuration::updateValue('CLERK_DATASYNC_INCLUDE_PAGES', array($this->language_id => $value), false, null, $this->shop_id);
@@ -81,10 +81,10 @@ class ClerkSetConfigModuleFrontController extends ClerkAbstractFrontController
                 Configuration::updateValue('CLERK_DATASYNC_PAGE_FIELDS', array($this->language_id => $value), false, null, $this->shop_id);
             }
             if ($key == "clerk_datasync_include_out_of_stock_products") {
-                Configuration::updateValue('CLERK_DATASYNC_INCLUDE_OUT_OF_STOCK_PRODUCTS', array($this->language_id => $value), false, null, $this->shop_id);
+                Configuration::updateValue('CLERK_DSYNC_INCL_OOS_PRODUCTS', array($this->language_id => $value), false, null, $this->shop_id);
             }
             if ($key == "clerk_datasync_include_only_local_stock") {
-                Configuration::updateValue('CLERK_DATASYNC_INCLUDE_ONLY_LOCAL_STOCK', array($this->language_id => $value), false, null, $this->shop_id);
+                Configuration::updateValue('CLERK_DSYNC_ONLY_LOCAL_STOCK', array($this->language_id => $value), false, null, $this->shop_id);
             }
             if ($key == "clerk_datasync_status_scope_shop") {
                 Configuration::updateValue('CLERK_DATASYNC_STATUS_SCOPE_SHOP', array($this->language_id => $value), false, null, $this->shop_id);
@@ -99,7 +99,7 @@ class ClerkSetConfigModuleFrontController extends ClerkAbstractFrontController
                 Configuration::updateValue('CLERK_DATASYNC_SYNC_SUBSCRIBERS', array($this->language_id => $value), false, null, $this->shop_id);
             }
             if ($key == "clerk_datasync_disable_customer_sync") {
-                Configuration::updateValue('CLERK_DATASYNC_DISABLE_CUSTOMER_SYNC', array($this->language_id => $value), false, null, $this->shop_id);
+                Configuration::updateValue('CLERK_DSYNC_DISABLE_CUST_SYNC', array($this->language_id => $value), false, null, $this->shop_id);
             }
             if ($key == "clerk_datasync_fields") {
                 Configuration::updateValue('CLERK_DATASYNC_FIELDS', array($this->language_id => $value), false, null, $this->shop_id);
@@ -177,10 +177,10 @@ class ClerkSetConfigModuleFrontController extends ClerkAbstractFrontController
                 Configuration::updateValue('CLERK_LIVESEARCH_FORM_SELECTOR', array($this->language_id => $value), false, null, $this->shop_id);
             }
             if ($key == "clerk_livesearch_number_suggestions") {
-                Configuration::updateValue('CLERK_LIVESEARCH_NUMBER_SUGGESTIONS', array($this->language_id => $value), false, null, $this->shop_id);
+                Configuration::updateValue('CLERK_LS_NUM_SUGGESTIONS', array($this->language_id => $value), false, null, $this->shop_id);
             }
             if ($key == "clerk_livesearch_number_categories") {
-                Configuration::updateValue('CLERK_LIVESEARCH_NUMBER_CATEGORIES', array($this->language_id => $value), false, null, $this->shop_id);
+                Configuration::updateValue('CLERK_LS_NUM_CATEGORIES', array($this->language_id => $value), false, null, $this->shop_id);
             }
             if ($key == "clerk_livesearch_number_pages") {
                 Configuration::updateValue('CLERK_LIVESEARCH_NUMBER_PAGES', array($this->language_id => $value), false, null, $this->shop_id);
@@ -189,7 +189,7 @@ class ClerkSetConfigModuleFrontController extends ClerkAbstractFrontController
                 Configuration::updateValue('CLERK_LIVESEARCH_PAGES_TYPE', array($this->language_id => $value), false, null, $this->shop_id);
             }
             if ($key == "clerk_livesearch_dropdown_position") {
-                Configuration::updateValue('CLERK_LIVESEARCH_DROPDOWN_POSITION', array($this->language_id => $value), false, null, $this->shop_id);
+                Configuration::updateValue('CLERK_LS_DROPDOWN_POSITION', array($this->language_id => $value), false, null, $this->shop_id);
             }
 
             // POWERSTEP SETTINGS (3)
@@ -250,13 +250,13 @@ class ClerkSetConfigModuleFrontController extends ClerkAbstractFrontController
                 Configuration::updateValue('CLERK_CART_EXCLUDE_DUPLICATES', array($this->language_id => $value), false, null, $this->shop_id);
             }
             if ($key == "clerk_powerstep_exclude_duplicates") {
-                Configuration::updateValue('CLERK_POWERSTEP_EXCLUDE_DUPLICATES', array($this->language_id => $value), false, null, $this->shop_id);
+                Configuration::updateValue('CLERK_PWRSTEP_EXCL_DUPLICATES', array($this->language_id => $value), false, null, $this->shop_id);
             }
             if ($key == "clerk_product_exclude_duplicates") {
                 Configuration::updateValue('CLERK_PRODUCT_EXCLUDE_DUPLICATES', array($this->language_id => $value), false, null, $this->shop_id);
             }
             if ($key == "clerk_category_exclude_duplicates") {
-                Configuration::updateValue('CLERK_CATEGORY_EXCLUDE_DUPLICATES', array($this->language_id => $value), false, null, $this->shop_id);
+                Configuration::updateValue('CLERK_CAT_EXCL_DUPLICATES', array($this->language_id => $value), false, null, $this->shop_id);
             }
             if ($key == "clerk_additional_scripts_enabled") {
                 Configuration::updateValue('CLERK_ADDITIONAL_SCRIPTS_ENABLED', array($this->language_id => $value), false, null, $this->shop_id);

--- a/helpers/Product.php
+++ b/helpers/Product.php
@@ -8,7 +8,7 @@ class ProductHelper {
      * @return false|string
      */
     public static function shouldLiveUpdate($shop_id, $language_id){
-         return Configuration::get('CLERK_DATASYNC_USE_REAL_TIME_UPDATES', $language_id, null, $shop_id);
+         return Configuration::get('CLERK_DSYNC_REALTIME_UPDATES', $language_id, null, $shop_id);
     }
 
     /**
@@ -728,11 +728,11 @@ class ProductHelper {
             $product_stock = (int) $product->quantity;
         }
 
-        if (!Configuration::get('CLERK_DATASYNC_INCLUDE_OUT_OF_STOCK_PRODUCTS', $language_id, null, $shop_id) && $product_stock <= 0) {
+        if (!Configuration::get('CLERK_DSYNC_INCL_OOS_PRODUCTS', $language_id, null, $shop_id) && $product_stock <= 0) {
             return;
         }
 
-        if (!Configuration::get('CLERK_DATASYNC_INCLUDE_ONLY_LOCAL_STOCK', $language_id, null, $shop_id) && $product_stock <= 0 && !$product->out_of_stock && !Configuration::get('CLERK_DATASYNC_INCLUDE_OUT_OF_STOCK_PRODUCTS', $language_id, null, $shop_id)) {
+        if (!Configuration::get('CLERK_DSYNC_ONLY_LOCAL_STOCK', $language_id, null, $shop_id) && $product_stock <= 0 && !$product->out_of_stock && !Configuration::get('CLERK_DSYNC_INCL_OOS_PRODUCTS', $language_id, null, $shop_id)) {
             return;
         }
 

--- a/upgrade/install-6.9.3.php
+++ b/upgrade/install-6.9.3.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ *  @author Clerk.io
+ *  @copyright Copyright (c) 2017 Clerk.io
+ *
+ *  @license MIT License
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Migrate configuration keys that exceeded the 32-character ps_configuration.name limit.
+ *
+ * Uses direct SQL UPDATE to rename keys in place, which:
+ *   - Preserves all values, shop associations, language entries, and timestamps
+ *   - Bypasses Configuration::get/set scope issues (global vs shop-specific storage)
+ *   - Handles both full keys (newer PS, VARCHAR 254) and truncated keys (older PS, VARCHAR 32)
+ *   - Is idempotent (safe to run multiple times)
+ */
+function upgrade_module_6_9_3($object)
+{
+    $keyMap = array(
+        'CLERK_LIVESEARCH_NUMBER_SUGGESTIONS'                  => 'CLERK_LS_NUM_SUGGESTIONS',
+        'CLERK_LIVESEARCH_NUMBER_CATEGORIES'                   => 'CLERK_LS_NUM_CATEGORIES',
+        'CLERK_LIVESEARCH_DROPDOWN_POSITION'                   => 'CLERK_LS_DROPDOWN_POSITION',
+        'CLERK_DATASYNC_USE_REAL_TIME_UPDATES'                 => 'CLERK_DSYNC_REALTIME_UPDATES',
+        'CLERK_DATASYNC_INCLUDE_OUT_OF_STOCK_PRODUCTS'         => 'CLERK_DSYNC_INCL_OOS_PRODUCTS',
+        'CLERK_DATASYNC_INCLUDE_ONLY_LOCAL_STOCK'              => 'CLERK_DSYNC_ONLY_LOCAL_STOCK',
+        'CLERK_DATASYNC_DISABLE_CUSTOMER_SYNC'                 => 'CLERK_DSYNC_DISABLE_CUST_SYNC',
+        'CLERK_POWERSTEP_EXCLUDE_DUPLICATES'                   => 'CLERK_PWRSTEP_EXCL_DUPLICATES',
+        'CLERK_CATEGORY_EXCLUDE_DUPLICATES'                    => 'CLERK_CAT_EXCL_DUPLICATES',
+        'CLERK_LOGGING_DATASYNC_COLLECT_EMAILS'                => 'CLERK_LOG_DSYNC_COLLECT_EMAILS',
+        'CLERK_LOGGING_DATASYNC_DISABLE_ORDER_SYNCHRONIZATION' => 'CLERK_LOG_DSYNC_NO_ORDER_SYNC',
+    );
+
+    $db = Db::getInstance();
+    $prefix = _DB_PREFIX_;
+
+    foreach ($keyMap as $oldKey => $newKey) {
+        $truncatedKey = substr($oldKey, 0, 32);
+
+        $newKeyExists = (int) $db->getValue(
+            "SELECT COUNT(*) FROM `{$prefix}configuration` WHERE `name` = '" . pSQL($newKey) . "'"
+        );
+
+        if ($newKeyExists > 0) {
+            // New key already exists (re-run or fresh install). Clean up any leftover old keys.
+            $oldIds = $db->executeS(
+                "SELECT `id_configuration` FROM `{$prefix}configuration`
+                 WHERE `name` = '" . pSQL($oldKey) . "' OR `name` = '" . pSQL($truncatedKey) . "'"
+            );
+            if (!empty($oldIds)) {
+                $ids = implode(',', array_column($oldIds, 'id_configuration'));
+                $db->execute("DELETE FROM `{$prefix}configuration_lang` WHERE `id_configuration` IN ({$ids})");
+                $db->execute("DELETE FROM `{$prefix}configuration` WHERE `id_configuration` IN ({$ids})");
+            }
+            continue;
+        }
+
+        // Try renaming the full old key in place
+        $db->execute(
+            "UPDATE `{$prefix}configuration` SET `name` = '" . pSQL($newKey) . "'
+             WHERE `name` = '" . pSQL($oldKey) . "'"
+        );
+
+        if ($db->Affected_Rows() == 0) {
+            // Full key not found — try the truncated variant (older PS with VARCHAR 32)
+            $db->execute(
+                "UPDATE `{$prefix}configuration` SET `name` = '" . pSQL($newKey) . "'
+                 WHERE `name` = '" . pSQL($truncatedKey) . "'"
+            );
+        } else {
+            // Full key was renamed. Clean up any orphaned truncated key.
+            $orphanIds = $db->executeS(
+                "SELECT `id_configuration` FROM `{$prefix}configuration`
+                 WHERE `name` = '" . pSQL($truncatedKey) . "'"
+            );
+            if (!empty($orphanIds)) {
+                $ids = implode(',', array_column($orphanIds, 'id_configuration'));
+                $db->execute("DELETE FROM `{$prefix}configuration_lang` WHERE `id_configuration` IN ({$ids})");
+                $db->execute("DELETE FROM `{$prefix}configuration` WHERE `id_configuration` IN ({$ids})");
+            }
+        }
+    }
+
+    return true;
+}


### PR DESCRIPTION
Test Passed

-  Fresh install on PrestaShop 9.0.2 with strict MySQL 
-  Fresh install on PrestaShop 1.7+ with strict MySQL
-  Fresh install on PrestaShop 1.6 with strict MySQL (VARCHAR 32)
-  Upgrade from 6.9.2 on single-shop setup 
-  Upgrade from 6.9.2 on multi-shop, multi-language setup
-  Verify all settings are preserved after upgrade 